### PR TITLE
INF-3030: Selects an AMI for the correct architecture

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -1,11 +1,15 @@
+data "aws_ec2_instance_type" "bastion_type" {
+  instance_type = var.instance_type
+}
+
 data "aws_ami" "amazon-linux-2" {
   most_recent = true
   owners      = ["amazon"]
-  name_regex  = "^amzn2-ami-hvm.*-ebs"
+  name_regex  = "^amzn2-ami-hvm.*-gp2"
 
   filter {
     name   = "architecture"
-    values = ["x86_64"]
+    values = data.aws_ec2_instance_type.bastion_type.supported_architectures
   }
 }
 
@@ -13,4 +17,3 @@ data "aws_subnet" "subnets" {
   count = length(var.elb_subnets)
   id    = var.elb_subnets[count.index]
 }
-

--- a/main.tf
+++ b/main.tf
@@ -242,7 +242,7 @@ resource "aws_launch_template" "bastion_launch_template" {
     device_name = "/dev/xvda"
     ebs {
       volume_size           = var.disk_size
-      volume_type           = "gp2"
+      volume_type           = "gp3"
       delete_on_termination = true
       encrypted             = var.disk_encrypt
       kms_key_id            = var.disk_encrypt ? data.aws_kms_alias.kms-ebs.target_key_arn : ""


### PR DESCRIPTION
For https://linear.app/roserocket/issue/INF-3030/upgrade-instance-type-of-production-bastion

Removes hardcoding of x86_64 for the instance type, uses a dynamic lookup for the architecture of the selected instance type instead. Practically speaking this allows us to use arm64 instances.